### PR TITLE
⬆️ Upgrade to 100.0.1

### DIFF
--- a/gluon.json
+++ b/gluon.json
@@ -5,7 +5,7 @@
   "binaryName": "pulse-browser",
   "version": {
     "product": "firefox",
-    "version": "100.0",
+    "version": "100.0.1",
     "displayVersion": "1.0.0"
   },
   "buildOptions": {


### PR DESCRIPTION
Depends on pulse-browser/gluon#10
Fixes macos icons: pulse-browser/browser#67
Closes #75 