### PR TITLE
126 switching out fire picker

### DIFF
--- a/gluon.json
+++ b/gluon.json
@@ -28,7 +28,7 @@
       "id": "qr-generator@browser.fushra.com",
       "platform": "github",
       "repo": "pulse-browser/firefox-qr-generator",
-      "version": "v0.0.0",
+      "version": "v0.1.0",
       "fileGlob": "release.zip"
     },
     "sidebar-tabs": {

--- a/gluon.json
+++ b/gluon.json
@@ -24,11 +24,11 @@
       "amoId": "850407",
       "version": "2.6.0"
     },
-    "firepicker": {
-      "id": "fire-picker@browser.fushra.com",
+    "firefox-qr-generator": {
+      "id": "qr-generator@browser.fushra.com",
       "platform": "github",
-      "repo": "pulse-browser/fire-picker",
-      "version": "v1.1.2",
+      "repo": "pulse-browser/firefox-qr-generator",
+      "version": "v0.0.0",
       "fileGlob": "release.zip"
     },
     "sidebar-tabs": {


### PR DESCRIPTION
Fire-picker at this point of time is dead and needs for a rewriting in terms of injection and optimization, more information can be found at the issue https://github.com/pulse-browser/fire-picker/issues/3 . In the state of feature freeze it is a good idea to replace it with https://github.com/pulse-browser/firefox-qr-generator an in house productivity extension.

Fixes #126

