### PR TITLE
Allow for signed and unsigned uBlock origin releases + update uBlock

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -15,7 +15,8 @@
   },
   "javascript.updateImportsOnFileMove.enabled": "always",
   "files.exclude": {
-    "**/node_modules": true
+    "**/node_modules": true,
+    "**/.gluon": true
   },
   "[html]": {
     "editor.formatOnSave": false

--- a/gluon.json
+++ b/gluon.json
@@ -16,7 +16,7 @@
       "id": "uBlock0@raymondhill.net",
       "repo": "gorhill/uBlock",
       "version": "1.44.4",
-      "fileGlob": "uBlock0_*.firefox.xpi"
+      "fileGlob": "uBlock0_*.firefox(.signed)?.xpi"
     },
     "tabliss": {
       "platform": "amo",


### PR DESCRIPTION
uBlock seems to alternate between using `.singed` and not using it, which is causing some problems. This should fix that and update uBlock to the latest version, because why not?

Closes #140 