### PR TITLE
Hide Sidebar on Simple Window (Popup)

### DIFF
--- a/src/browser/base/content/browser-sidebar-js.patch
+++ b/src/browser/base/content/browser-sidebar-js.patch
@@ -1,5 +1,5 @@
 diff --git a/browser/base/content/browser-sidebar.js b/browser/base/content/browser-sidebar.js
-index c5ac301416d2d820ba95e21c0ce1fe305e63b554..513dcacbe33770cfafb57bdcadfd64b6fb999eef 100644
+index c5ac301416d2d820ba95e21c0ce1fe305e63b554..4d824259fd611e5531e35bb3d3da85f587815197 100644
 --- a/browser/base/content/browser-sidebar.js
 +++ b/browser/base/content/browser-sidebar.js
 @@ -11,6 +11,10 @@ var SidebarUI = {
@@ -42,8 +42,8 @@ index c5ac301416d2d820ba95e21c0ce1fe305e63b554..513dcacbe33770cfafb57bdcadfd64b6
            url: "chrome://browser/content/syncedtabs/sidebar.xhtml",
            menuId: "menu_tabsSidebar",
 +          iconurl: "chrome://browser/skin/tab.svg",
-+        }),
-+      ],
+         }),
+       ],
 +      [
 +        "viewDownloadsSidebar",
 +        makeSidebar({
@@ -52,8 +52,8 @@ index c5ac301416d2d820ba95e21c0ce1fe305e63b554..513dcacbe33770cfafb57bdcadfd64b6
 +          url: "about:downloads",
 +          menuId: "menu_downloadsSidebar",
 +          iconurl: "chrome://browser/skin/downloads/downloads.svg",
-         }),
-       ],
++        }),
++      ],
 +      [
 +        "sidebar-view-addons",
 +        {
@@ -100,7 +100,7 @@ index c5ac301416d2d820ba95e21c0ce1fe305e63b554..513dcacbe33770cfafb57bdcadfd64b6
    _reversePositionButton: null,
    _switcherPanel: null,
    _switcherTarget: null,
-@@ -110,15 +154,58 @@ var SidebarUI = {
+@@ -110,15 +154,59 @@ var SidebarUI = {
      this._switcherTarget = document.getElementById("sidebar-switcher-target");
      this._switcherArrow = document.getElementById("sidebar-switcher-arrow");
  
@@ -129,10 +129,11 @@ index c5ac301416d2d820ba95e21c0ce1fe305e63b554..513dcacbe33770cfafb57bdcadfd64b6
 +      this.createSidebarItem(sidebaritem, this.sidebars.get(sidebaritem), true);
 +    }
 +
-+    const sidebarVisible = Services.prefs.getBoolPref(
-+      this.SIDEBAR_TABS_PREF,
-+      true
-+    );
++    let sidebarVisible = false;
++    if (window.toolbar.visible) {
++      sidebarVisible = Services.prefs.getBoolPref(this.SIDEBAR_TABS_PREF, true);
++    }
++
 +    this.setSidebarVisibility(sidebarVisible);
 +
 +    // Keep track on the changes of the sidebar visibility
@@ -159,7 +160,7 @@ index c5ac301416d2d820ba95e21c0ce1fe305e63b554..513dcacbe33770cfafb57bdcadfd64b6
    },
  
    uninit() {
-@@ -127,7 +214,10 @@ var SidebarUI = {
+@@ -127,7 +215,10 @@ var SidebarUI = {
      let enumerator = Services.wm.getEnumerator("navigator:browser");
      if (!enumerator.hasMoreElements()) {
        let xulStore = Services.xulStore;
@@ -171,7 +172,7 @@ index c5ac301416d2d820ba95e21c0ce1fe305e63b554..513dcacbe33770cfafb57bdcadfd64b6
  
        if (this._box.hasAttribute("positionend")) {
          xulStore.persist(this._box, "positionend");
-@@ -148,6 +238,12 @@ var SidebarUI = {
+@@ -148,6 +239,12 @@ var SidebarUI = {
        xulStore.persist(this._title, "value");
      }
  
@@ -184,7 +185,7 @@ index c5ac301416d2d820ba95e21c0ce1fe305e63b554..513dcacbe33770cfafb57bdcadfd64b6
      Services.obs.removeObserver(this, "intl:app-locales-changed");
  
      if (this._observer) {
-@@ -159,17 +255,47 @@ var SidebarUI = {
+@@ -159,17 +256,47 @@ var SidebarUI = {
    /**
     * The handler for Services.obs.addObserver.
     **/
@@ -236,7 +237,7 @@ index c5ac301416d2d820ba95e21c0ce1fe305e63b554..513dcacbe33770cfafb57bdcadfd64b6
        }
      }
    },
-@@ -485,6 +611,9 @@ var SidebarUI = {
+@@ -485,6 +612,9 @@ var SidebarUI = {
    },
  
    _loadSidebarExtension(commandID) {
@@ -246,7 +247,7 @@ index c5ac301416d2d820ba95e21c0ce1fe305e63b554..513dcacbe33770cfafb57bdcadfd64b6
      let sidebar = this.sidebars.get(commandID);
      let { extensionId } = sidebar;
      if (extensionId) {
-@@ -523,6 +652,7 @@ var SidebarUI = {
+@@ -523,6 +653,7 @@ var SidebarUI = {
        }
  
        this._fireFocusedEvent();
@@ -254,7 +255,7 @@ index c5ac301416d2d820ba95e21c0ce1fe305e63b554..513dcacbe33770cfafb57bdcadfd64b6
        return true;
      });
    },
-@@ -546,10 +676,28 @@ var SidebarUI = {
+@@ -546,10 +677,28 @@ var SidebarUI = {
      }
      return this._show(commandID).then(() => {
        this._loadSidebarExtension(commandID);
@@ -283,7 +284,7 @@ index c5ac301416d2d820ba95e21c0ce1fe305e63b554..513dcacbe33770cfafb57bdcadfd64b6
    /**
     * Implementation for show. Also used internally for sidebars that are shown
     * when a window is opened and we don't want to ping telemetry.
-@@ -559,6 +707,29 @@ var SidebarUI = {
+@@ -559,6 +708,29 @@ var SidebarUI = {
     */
    _show(commandID) {
      return new Promise(resolve => {
@@ -313,7 +314,7 @@ index c5ac301416d2d820ba95e21c0ce1fe305e63b554..513dcacbe33770cfafb57bdcadfd64b6
        this.selectMenuItem(commandID);
  
        this._box.hidden = this._splitter.hidden = false;
-@@ -570,13 +741,21 @@ var SidebarUI = {
+@@ -570,13 +742,21 @@ var SidebarUI = {
        this._box.setAttribute("sidebarcommand", commandID);
        this.lastOpenedId = commandID;
  
@@ -337,7 +338,7 @@ index c5ac301416d2d820ba95e21c0ce1fe305e63b554..513dcacbe33770cfafb57bdcadfd64b6
          this.browser.addEventListener(
            "load",
            event => {
-@@ -615,22 +794,46 @@ var SidebarUI = {
+@@ -615,22 +795,46 @@ var SidebarUI = {
  
      this.selectMenuItem("");
  
@@ -391,7 +392,7 @@ index c5ac301416d2d820ba95e21c0ce1fe305e63b554..513dcacbe33770cfafb57bdcadfd64b6
    },
  
    /**
-@@ -638,25 +841,121 @@ var SidebarUI = {
+@@ -638,25 +842,121 @@ var SidebarUI = {
     * none if the argument is an empty string.
     */
    selectMenuItem(commandID) {


### PR DESCRIPTION
In general, the use case for displaying a sidebar in a small window, such as a login authentication window or debugging tool, is rare. These types of windows are typically designed to perform a specific task and do not require the additional screen real estate or functionality that a sidebar would provide. Additionally, the limited size of these windows may make it difficult to effectively utilize a sidebar without compromising the usability of the primary content.

For these reasons, it may be more appropriate to omit the sidebar in small windows that utilize the Window API or do not have an omnibox. This allows for a streamlined user experience that is focused on the primary task at hand, rather than being cluttered with unnecessary features. 