### PR TITLE
🐛 Fix firefox sync

### DIFF
--- a/src/browser/app/profile/pulse-browser.js
+++ b/src/browser/app/profile/pulse-browser.js
@@ -7,6 +7,9 @@
 // Betterfox has a lower priority than the prefs included in this file
 #include better-fox.js
 
+// Betterfox overrides:
+pref('identity.fxaccounts.enabled', true); // Enable firefox sync
+
 // Enable importers for other browsers
 pref('browser.migrate.vivaldi.enabled', true);
 pref('browser.migrate.opera-gx.enabled', true);
@@ -63,4 +66,3 @@ pref("app.releaseNotesURL.aboutDialog", "https://discord.gg/Y3khyEtAgS");
 
 // This pref needs to be here to not break context menus (GH#169)
 pref("extensions.pocket.enabled", false);
-


### PR DESCRIPTION
Regressed by #206 
Fixes #207 

Betterfox disables Firefox sync by default. This reenables it. I need to go through at some point in the future and check all of the prefs.