### PR TITLE
Fix wayland app name

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,16 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "gdb",
+      "request": "launch",
+      "name": "Launch Pulse (Linux)",
+      "target": "${workspaceFolder}/engine/obj-x86_64-pc-linux-gnu/dist/bin/pulse-browser",
+      "cwd": "${workspaceRoot}",
+      "valuesFormatting": "parseText"
+    }
+  ]
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.0.0-a.62
+
+### Fixed
+
+- Specified wayland app name (#231)
+
 ## 1.0.0-a.61
 
 ### Added

--- a/configs/common/mozconfig
+++ b/configs/common/mozconfig
@@ -12,6 +12,7 @@ export MOZ_APP_DISPLAYNAME="Pulse browser"
 export MOZ_MACBUNDLE_ID=com.fushra.browser.alpha
 export MOZ_DISTRIBUTION_ID=com.fushra.browser.alpha
 export MOZ_MACBUNDLE_NAME="Pulse browser.app"
+export MOZ_APP_REMOTINGNAME=com.fushra.browser.alpha
 
 # Misc
 export MOZ_INCLUDE_SOURCE_INFO=1


### PR DESCRIPTION
The wayland app field is used to set the desktop file. If set incorrectly (which it is at the moment) KDE will refuse to display the correct icons in flatpaks. 

Bugzilla: https://bugzilla.mozilla.org/show_bug.cgi?id=1782448
KDE: https://bugs.kde.org/show_bug.cgi?id=459536

Note, `MOZ_APP_REMOTINGNAME` is used by `g_set_prgname` elsewhere in the application.