### PR TITLE
Fix uBo (network blocking) in sidebar webpages

### DIFF
--- a/gluon.json
+++ b/gluon.json
@@ -5,7 +5,7 @@
   "binaryName": "pulse-browser",
   "version": {
     "product": "firefox",
-    "version": "111.0"
+    "version": "112.0"
   },
   "buildOptions": {
     "generateBranding": true
@@ -15,7 +15,7 @@
       "platform": "github",
       "id": "uBlock0@raymondhill.net",
       "repo": "gorhill/uBlock",
-      "version": "1.47.4",
+      "version": "1.48.8",
       "fileGlob": "uBlock0_*.firefox(.signed)?.xpi"
     },
     "tabliss": {
@@ -93,9 +93,7 @@
     }
   },
   "license": {
-    "ignoredFiles": [
-      ".*\\.json"
-    ],
+    "ignoredFiles": [".*\\.json"],
     "licenseType": "MPL-2.0"
   },
   "updateHostname": "updates.pulsebrowser.app"

--- a/gluon.json
+++ b/gluon.json
@@ -93,7 +93,9 @@
     }
   },
   "license": {
-    "ignoredFiles": [".*\\.json"],
+    "ignoredFiles": [
+      ".*\\.json"
+    ],
     "licenseType": "MPL-2.0"
   },
   "updateHostname": "updates.pulsebrowser.app"

--- a/src/browser/app/profile/better-fox.js
+++ b/src/browser/app/profile/better-fox.js
@@ -35,7 +35,7 @@
 /****************************************************************************
  * Betterfox                                                                *
  * "Ad meliora"                                                             *
- * version: 111                                                             *
+ * version: 112                                                             *
  * url: https://github.com/yokoffing/Betterfox                              *
  ****************************************************************************/
 
@@ -154,7 +154,6 @@ pref('signon.privateBrowsingCapture.enabled', false);
 pref('signon.autofillForms', false);
 pref('signon.rememberSignons', false);
 pref('editor.truncate_user_pastes', false);
-pref('layout.forms.reveal-password-context-menu.enabled', true);
 
 /** ADDRESS + CREDIT CARD MANAGER ***/
 pref('extensions.formautofill.addresses.enabled', false);
@@ -254,7 +253,7 @@ pref('browser.privatebrowsing.enable-new-indicator', false);
 /** FULLSCREEN ***/
 pref('full-screen-api.transition-duration.enter', '0 0');
 pref('full-screen-api.transition-duration.leave', '0 0');
-pref('full-screen-api.warning.delay', 0);
+pref('full-screen-api.warning.delay', -1);
 pref('full-screen-api.warning.timeout', 0);
 
 /** URL BAR ***/

--- a/src/browser/base/content/webext-panels-js.patch
+++ b/src/browser/base/content/webext-panels-js.patch
@@ -1,0 +1,13 @@
+diff --git a/browser/base/content/webext-panels.js b/browser/base/content/webext-panels.js
+index 22a5c0b4b6382fa5290391a14f7dd680a10a1ce1..fa8c68161914b230bf7ff3dbe7ab82e409630069 100644
+--- a/browser/base/content/webext-panels.js
++++ b/browser/base/content/webext-panels.js
+@@ -38,7 +38,7 @@ function getBrowser(panel) {
+   browser.setAttribute("type", "content");
+   browser.setAttribute("flex", "1");
+   browser.setAttribute("disableglobalhistory", "true");
+-  browser.setAttribute("messagemanagergroup", "webext-browsers");
++  browser.setAttribute("messagemanagergroup", !panel.uri.includes('http') ? "webext-browsers" : "browsers");
+   browser.setAttribute("webextension-view-type", panel.viewType);
+   browser.setAttribute("context", "contentAreaContextMenu");
+   browser.setAttribute("tooltip", "aHTMLTooltip");

--- a/src/browser/components/urlbar/UrlbarInput-sys-mjs.patch
+++ b/src/browser/components/urlbar/UrlbarInput-sys-mjs.patch
@@ -1,11 +1,11 @@
 diff --git a/browser/components/urlbar/UrlbarInput.sys.mjs b/browser/components/urlbar/UrlbarInput.sys.mjs
-index c2b886df8188350b8c4586ed517b089d5eafe447..bb5bb690aedbeb3a7329ac78a8c813c35ee1295c 100644
+index fabe5a334b5c2e2f41ddd6d7b871a3a68affae28..0e80439af0ec560b8eddd1b4657956097cee968a 100644
 --- a/browser/components/urlbar/UrlbarInput.sys.mjs
 +++ b/browser/components/urlbar/UrlbarInput.sys.mjs
-@@ -369,6 +369,17 @@ export class UrlbarInput {
-         !dueToSessionRestore &&
-         (!this.window.isBlankPageURL(uri.spec) ||
-           uri.schemeIs("moz-extension"));
+@@ -398,6 +398,16 @@ export class UrlbarInput {
+           !dueToSessionRestore &&
+           (!this.window.isBlankPageURL(uri.spec) ||
+             uri.schemeIs("moz-extension"));
 +
 +      // Check if the addon is tabliss (our new tab) and stop if from showing up
 +      // as such
@@ -16,7 +16,6 @@ index c2b886df8188350b8c4586ed517b089d5eafe447..bb5bb690aedbeb3a7329ac78a8c813c3
 +          valid = false
 +        }
 +      } catch (e) {}
-+
+       }
      } else if (
        this.window.isInitialPage(value) &&
-       lazy.BrowserUIUtils.checkEmptyPageOrigin(

--- a/src/devtools/client/performance-new/panel/index-xhtml.patch
+++ b/src/devtools/client/performance-new/panel/index-xhtml.patch
@@ -1,7 +1,7 @@
-diff --git a/devtools/client/performance-new/index.xhtml b/devtools/client/performance-new/index.xhtml
-index e77548dcbd98a598822e080805d0e320310f3103..3011e0c0b84f9002b499f1ac2343c6c7bd34b372 100644
---- a/devtools/client/performance-new/index.xhtml
-+++ b/devtools/client/performance-new/index.xhtml
+diff --git a/devtools/client/performance-new/panel/index.xhtml b/devtools/client/performance-new/panel/index.xhtml
+index bdde2207d116069ca17dcb00ad7d1c6405b6fbe5..72dfd14eb2dd77e94bb596347e4275ee14f4a48b 100644
+--- a/devtools/client/performance-new/panel/index.xhtml
++++ b/devtools/client/performance-new/panel/index.xhtml
 @@ -13,6 +13,7 @@
    <head>
      <link rel="stylesheet" href="chrome://devtools/skin/widgets.css" type="text/css"/>

--- a/src/toolkit/content/plugins-html.patch
+++ b/src/toolkit/content/plugins-html.patch
@@ -1,11 +1,11 @@
 diff --git a/toolkit/content/plugins.html b/toolkit/content/plugins.html
-index 84855798c78cbd5b4c039f179b672ec425c03347..9b0528ff8e63c0a575fbcb99165691750f4a9578 100644
+index 5972127902912610d47c146dafde68e0dd3a1bd5..600ab54928cf87d0ec8888bcb1ce5730f70c5db5 100644
 --- a/toolkit/content/plugins.html
 +++ b/toolkit/content/plugins.html
-@@ -12,6 +12,7 @@
- <title data-l10n-id="title-label"></title>
- <link rel="stylesheet" href="chrome://global/content/plugins.css">
+@@ -14,6 +14,7 @@
  <link rel="localization" href="toolkit/about/aboutPlugins.ftl"/>
+ <script src="chrome://global/content/customElements.js"></script>
+ <script type="module" src="chrome://global/content/elements/moz-support-link.mjs"></script>
 +<script src="chrome://browser/content/contentTheme.js"></script>
  </head>
  <body>

--- a/src/toolkit/themes/shared/in-content/common-shared-css.patch
+++ b/src/toolkit/themes/shared/in-content/common-shared-css.patch
@@ -1,17 +1,17 @@
 diff --git a/toolkit/themes/shared/in-content/common-shared.css b/toolkit/themes/shared/in-content/common-shared.css
-index 35597e57e2af87d44b5b6f984c50705f70745d73..b2f69caa83256374e5a5d51e5b9203eb0193b1bc 100644
+index c88471068bca47b1bda1c307e1921f1936f24fb9..fdd2212d892047606b1b41c4e3dbadca5cc7169a 100644
 --- a/toolkit/themes/shared/in-content/common-shared.css
 +++ b/toolkit/themes/shared/in-content/common-shared.css
-@@ -261,8 +261,6 @@
+@@ -263,8 +263,6 @@
  :root {
    font: message-box;
    appearance: none;
 -  background-color: var(--in-content-page-background);
 -  color: var(--in-content-page-color);
-   -moz-box-layout: flex;
  }
  
-@@ -272,6 +270,8 @@
+ :root:not(.system-font-size) {
+@@ -273,6 +271,8 @@
  
  html|body {
    margin: 0;


### PR DESCRIPTION
@surapunoyousei you might find this interesting. The reason why ads aren't blocked in the sidebar is because the  `messagemanagergroup` is set to `webext-browsers` on the container `<browser>` element. If you set it to `browsers`, it treats it as a regular browser (e.g. no webext permissions, content scripts work, etc). 

## References
Depends on #237 
Fixes #157 